### PR TITLE
Added 4th parameter to dBug constructor.

### DIFF
--- a/dBug.php
+++ b/dBug.php
@@ -66,7 +66,7 @@ class dBug {
 	var $arrHistory = array();
 
 	//constructor
-	function dBug($var,$forceType="",$bCollapsed=false, $reinit = false) {
+	function __construct($var,$forceType="",$bCollapsed=false, $reinit = false) {
 		//include js and css scripts
         if(!defined('BDBUGINIT') || $reinit) {
             if(!defined('BDBUGINIT')){

--- a/dBug.php
+++ b/dBug.php
@@ -190,7 +190,7 @@ class dBug {
 		$var_ser = serialize($var);
 		array_push($this->arrHistory, $var_ser);
 
-		$this->makeTableHeader("array","array");
+		$this->makeTableHeader("array","array (size: ".sizeof($var).")");
 		if(is_array($var)) {
 			foreach($var as $key=>$value) {
 				$this->makeTDHeader("array",$key);
@@ -220,7 +220,7 @@ class dBug {
 	function varIsObject($var) {
 		$var_ser = serialize($var);
 		array_push($this->arrHistory, $var_ser);
-		$this->makeTableHeader("object","object");
+		$this->makeTableHeader("object","object .(".get_class($var).")");
 
 		if(is_object($var)) {
 			$arrObjVars=get_object_vars($var);
@@ -255,7 +255,7 @@ class dBug {
 
 	//if variable is a resource type
 	function varIsResource($var) {
-		$this->makeTableHeader("resourceC","resource",1);
+		$this->makeTableHeader("resourceC","resource (".get_resource_type($var).")",1);
 		echo "<tr>\n<td>\n";
 		switch(get_resource_type($var)) {
 			case "fbsql result":

--- a/dBug.php
+++ b/dBug.php
@@ -66,12 +66,14 @@ class dBug {
 	var $arrHistory = array();
 
 	//constructor
-	function dBug($var,$forceType="",$bCollapsed=false) {
+	function dBug($var,$forceType="",$bCollapsed=false, $reinit = false) {
 		//include js and css scripts
-		if(!defined('BDBUGINIT')) {
-			define("BDBUGINIT", TRUE);
-			$this->initJSandCSS();
-		}
+        if(!defined('BDBUGINIT') || $reinit) {
+            if(!defined('BDBUGINIT')){
+                define("BDBUGINIT", TRUE);
+            }
+            $this->initJSandCSS();
+        }
 		$arrAccept=array("array","object","xml"); //array of variable types that can be "forced"
 		$this->bCollapsed = $bCollapsed;
 		if(in_array($forceType,$arrAccept))


### PR DESCRIPTION
With this optional parameter, that is false by default, you can trigger
the init of the JS and CSS. This is needed if you want to use dBug
multiple time to e.g. create multiple files (using ob_start etc. ).
Until now it would only generate those sections on the first constructor
call.
