### PR TITLE
Adding support for PSR-4 namespacing and modern constructors

### DIFF
--- a/dBug.php
+++ b/dBug.php
@@ -104,7 +104,7 @@ class dBug {
 			$code = $arrLines[($arrFile["line"]-1)];
 
 			//find call to dBug class
-			preg_match('/\bnew dBug\s*\(\s*(.+)\s*\);/i', $code, $arrMatches);
+			preg_match('/\bnew\s+(?:.*\\\\)?dBug\s*\(\s*(.+)\s*\);/i', $code, $arrMatches);
 
 			return $arrMatches[1];
 		}

--- a/dBug.php
+++ b/dBug.php
@@ -65,9 +65,17 @@ class dBug {
 	var $bCollapsed = false;
 	var $arrHistory = array();
 
-	//constructor
-	function dBug($var,$forceType="",$bCollapsed=false) {
-		//include js and css scripts
+	// maintain both styles of constructor for potential backwards compat issues?
+	public function __construct($var,$forceType="",$bCollapsed=false){
+		return $this->init($var,$forceType,$bCollapsed);
+	}
+
+	// TODO: bit the bullet and retire old-skool version
+	public function dBug($var,$forceType="",$bCollapsed=false){
+		return $this->init($var,$forceType,$bCollapsed);
+	}
+
+	private function init($var, $forceType, $bCollapsed) {
 		if(!defined('BDBUGINIT')) {
 			define("BDBUGINIT", TRUE);
 			$this->initJSandCSS();


### PR DESCRIPTION
I found when I was loading dBug via Composer it was giving me a warning that the pattern you were using could not find a match. This was because one needs to do this:

new \dBug($someVar);

and your pattern was not expecting the "\"

The new pattern allows for a namespace before the classname.

I've tested it with:

new dBug($someVar);
new \dBug($someVar);
new \namespace\dBug($someVar);
new \name\space\dBug($someVar);

Cheers.
